### PR TITLE
Add an ordered IndexedDB commit barrier

### DIFF
--- a/crates/sqlite-wasm-vfs/Cargo.toml
+++ b/crates/sqlite-wasm-vfs/Cargo.toml
@@ -31,6 +31,9 @@ web-sys = { version = "0.3.81", features = [
 ]}
 indexed_db_futures = "0.6.4"
 
+[features]
+test-util = []
+
 [dev-dependencies]
 wasm-bindgen-test = "0.3.54"
 sqlite-wasm-rs = { version = "0.5.1", default-features = false }

--- a/crates/sqlite-wasm-vfs/src/relaxed_idb.rs
+++ b/crates/sqlite-wasm-vfs/src/relaxed_idb.rs
@@ -364,12 +364,14 @@ struct RelaxedIdb {
     name2file: RefCell<HashMap<String, IdbFile>>,
     tx: UnboundedSender<IdbCommit>,
     commit_errors: RefCell<Vec<CommitFailure>>,
+    fatal_error: RefCell<Option<String>>,
     #[cfg(feature = "test-util")]
     fail_next_commit: Cell<bool>,
 }
 
 struct CommitFailure {
     op: IdbCommitOp,
+    incarnation: Option<u64>,
     message: String,
     count: u32,
 }
@@ -396,6 +398,7 @@ impl RelaxedIdb {
             name2file: RefCell::new(name2file),
             tx,
             commit_errors: RefCell::new(Vec::new()),
+            fatal_error: RefCell::new(None),
             #[cfg(feature = "test-util")]
             fail_next_commit: Cell::new(false),
         })
@@ -683,18 +686,41 @@ impl RelaxedIdb {
     }
 
     fn record_commit_error(&self, op: IdbCommitOp, error: &RelaxedIdbError) {
+        if matches!(op, IdbCommitOp::Delete(_) | IdbCommitOp::Clear) {
+            let mut fatal = self.fatal_error.borrow_mut();
+            if fatal.is_none() {
+                *fatal = Some(error.to_string());
+            }
+            return;
+        }
+        let incarnation = match &op {
+            IdbCommitOp::Sync(file) => self.file_incarnation(file),
+            _ => None,
+        };
         let mut pending = self.commit_errors.borrow_mut();
         if let Some(failure) = pending.iter_mut().find(|failure| same_op(&failure.op, &op)) {
             failure.count = failure.count.saturating_add(1);
         } else if pending.len() < 32 {
             pending.push(CommitFailure {
                 op,
+                incarnation,
                 message: error.to_string(),
                 count: 1,
             });
         } else if let Some(failure) = pending.last_mut() {
             failure.count = failure.count.saturating_add(1);
+            *self.fatal_error.borrow_mut() = Some("too many distinct IndexedDB failures".into());
         }
+    }
+
+    fn file_incarnation(&self, file: &str) -> Option<u64> {
+        self.name2file
+            .borrow()
+            .get(file)
+            .and_then(|entry| match entry {
+                IdbFile::Main(file) => Some(file.incarnation),
+                IdbFile::Temp(_) => None,
+            })
     }
 
     fn retry_operation<'a>(
@@ -704,22 +730,34 @@ impl RelaxedIdb {
         Box::pin(async move {
             match op {
                 IdbCommitOp::Sync(file) => self.sync_db_impl(file).await,
-                IdbCommitOp::Delete(file) => self.delete_db_impl(file).await,
-                IdbCommitOp::Clear => clear_impl(&self.idb).await,
-                IdbCommitOp::Barrier(_) => Ok(()),
+                IdbCommitOp::Delete(_) | IdbCommitOp::Clear | IdbCommitOp::Barrier(_) => Err(
+                    RelaxedIdbError::Generic("destructive commit failure cannot be retried".into()),
+                ),
             }
         })
     }
 
     async fn barrier_impl(&self, file: &str) -> Result<()> {
+        if let Some(error) = self.fatal_error.borrow().clone() {
+            return Err(RelaxedIdbError::Generic(error));
+        }
         let pending = std::mem::take(&mut *self.commit_errors.borrow_mut());
         let mut unresolved = Vec::new();
         let mut reported = None;
         for failure in pending {
+            let Some(failed_file) = op_file(&failure.op) else {
+                *self.fatal_error.borrow_mut() = Some(failure.message.clone());
+                return Err(RelaxedIdbError::Generic(failure.message));
+            };
+            if self.file_incarnation(failed_file) != failure.incarnation {
+                *self.fatal_error.borrow_mut() = Some(failure.message.clone());
+                return Err(RelaxedIdbError::Generic(failure.message));
+            }
             match self.retry_operation(&failure.op).await {
                 Ok(()) => reported = Some(failure.message),
                 Err(error) => unresolved.push(CommitFailure {
                     op: failure.op,
+                    incarnation: failure.incarnation,
                     message: format!("{}; retry failed: {error}", failure.message),
                     count: failure.count,
                 }),
@@ -731,8 +769,14 @@ impl RelaxedIdb {
         }
         for name in files {
             if let Err(error) = self.sync_db_impl(&name).await {
+                let incarnation = self.file_incarnation(&name);
+                if incarnation.is_none() {
+                    *self.fatal_error.borrow_mut() = Some(error.to_string());
+                    return Err(error);
+                }
                 unresolved.push(CommitFailure {
                     op: IdbCommitOp::Sync(name),
+                    incarnation,
                     message: error.to_string(),
                     count: 1,
                 });
@@ -750,6 +794,13 @@ impl RelaxedIdb {
             return Err(RelaxedIdbError::Generic(message));
         }
         Ok(())
+    }
+}
+
+fn op_file(op: &IdbCommitOp) -> Option<&str> {
+    match op {
+        IdbCommitOp::Sync(file) => Some(file),
+        _ => None,
     }
 }
 

--- a/crates/sqlite-wasm-vfs/src/relaxed_idb.rs
+++ b/crates/sqlite-wasm-vfs/src/relaxed_idb.rs
@@ -130,6 +130,7 @@ enum IdbCommitOp {
     Sync(String),
     Delete(String),
     Clear,
+    Barrier,
 }
 
 enum IdbFile {
@@ -325,6 +326,7 @@ struct RelaxedIdb {
     idb: Database,
     name2file: RefCell<HashMap<String, IdbFile>>,
     tx: UnboundedSender<IdbCommit>,
+    commit_errors: RefCell<Vec<String>>,
 }
 
 impl RelaxedIdb {
@@ -348,6 +350,7 @@ impl RelaxedIdb {
             idb: indexed_db,
             name2file: RefCell::new(name2file),
             tx,
+            commit_errors: RefCell::new(Vec::new()),
         })
     }
 
@@ -372,6 +375,10 @@ impl RelaxedIdb {
             ));
         }
         Ok(WaitCommit(rx))
+    }
+
+    fn barrier(&self) -> Result<WaitCommit> {
+        self.send_task_with_notify(IdbCommitOp::Barrier)
     }
 
     async fn preload_db(&self, files: Vec<String>) -> Result<()> {
@@ -491,25 +498,32 @@ impl RelaxedIdb {
     // already drop
     #[allow(clippy::await_holding_refcell_ref)]
     async fn sync_db_impl(&self, file: &str) -> Result<()> {
-        let mut name2file = self.name2file.borrow_mut();
-        let Some(idb_file) = name2file.get_mut(file) else {
-            return Ok(());
-        };
-
-        let IdbFile::Main(idb_blocks) = idb_file else {
-            return Ok(());
-        };
-
-        idb_blocks.sync_notified = false;
-
-        let file_size = idb_blocks.file_size;
-        let mut truncated_offset = idb_blocks.file_size;
-        while idb_blocks.blocks.remove(&truncated_offset).is_some() {
-            truncated_offset += idb_blocks.block_size;
+        if let Some(IdbFile::Main(idb_blocks)) = self.name2file.borrow_mut().get_mut(file) {
+            idb_blocks.sync_notified = false;
         }
 
-        let tx_blocks = std::mem::take(&mut idb_blocks.tx_blocks);
-        if tx_blocks.is_empty() && file_size == truncated_offset {
+        let (file_size, tx_blocks, blocks_to_put, has_truncation) = {
+            let name2file = self.name2file.borrow();
+            let Some(IdbFile::Main(idb_blocks)) = name2file.get(file) else {
+                return Ok(());
+            };
+
+            let file_size = idb_blocks.file_size;
+            let tx_blocks: Vec<_> = idb_blocks.tx_blocks.iter().copied().collect();
+            let blocks_to_put: Vec<_> = tx_blocks
+                .iter()
+                .filter_map(|offset| {
+                    idb_blocks
+                        .blocks
+                        .get(offset)
+                        .map(|buffer| (*offset, buffer.clone()))
+                })
+                .collect();
+            let has_truncation = idb_blocks.blocks.keys().any(|offset| *offset >= file_size);
+            (file_size, tx_blocks, blocks_to_put, has_truncation)
+        };
+
+        if blocks_to_put.is_empty() && !has_truncation {
             // no need to put or delete
             return Ok(());
         }
@@ -524,17 +538,22 @@ impl RelaxedIdb {
 
         let store = transaction.object_store("blocks")?;
 
-        for offset in tx_blocks {
-            if let Some(buffer) = idb_blocks.blocks.get(&offset) {
-                store.put(&set_block(&path, offset, buffer)).build()?;
-            }
+        for (offset, buffer) in &blocks_to_put {
+            store.put(&set_block(&path, *offset, buffer)).build()?;
         }
         store.delete(key_range(file, file_size)).build()?;
-
-        // The `RefMut` from `name2file` is explicitly dropped here to avoid holding the borrow across an `.await` point.
-        drop(name2file);
-
         transaction.commit().await?;
+
+        let mut name2file = self.name2file.borrow_mut();
+        if let Some(IdbFile::Main(idb_blocks)) = name2file.get_mut(file) {
+            idb_blocks
+                .blocks
+                .retain(|offset, _| *offset < idb_blocks.file_size);
+            for offset in tx_blocks {
+                idb_blocks.tx_blocks.remove(&offset);
+            }
+            idb_blocks.sync_notified = false;
+        }
 
         Ok(())
     }
@@ -542,11 +561,28 @@ impl RelaxedIdb {
     async fn commit_loop(&self, mut rx: UnboundedReceiver<IdbCommit>) {
         while let Some(commit) = rx.recv().await {
             let IdbCommit { op, notify } = commit;
+            let is_barrier = matches!(&op, IdbCommitOp::Barrier);
             let ret = match op {
                 IdbCommitOp::Sync(file) => self.sync_db_impl(&file).await,
                 IdbCommitOp::Delete(file) => self.delete_db_impl(&file).await,
                 IdbCommitOp::Clear => clear_impl(&self.idb).await,
+                IdbCommitOp::Barrier => {
+                    let errors = std::mem::take(&mut *self.commit_errors.borrow_mut());
+                    if errors.is_empty() {
+                        Ok(())
+                    } else {
+                        Err(RelaxedIdbError::Generic(format!(
+                            "one or more IndexedDB commits failed: {}",
+                            errors.join("; ")
+                        )))
+                    }
+                }
             };
+            if !is_barrier {
+                if let Err(error) = &ret {
+                    self.commit_errors.borrow_mut().push(error.to_string());
+                }
+            }
             if let Some(notify) = notify {
                 // An unsuccessful send would be one where the corresponding receiver
                 // has already been deallocated.
@@ -883,6 +919,16 @@ impl RelaxedIdbUtil {
     /// Delete the specified database, make sure that the database is closed.
     pub fn delete_db(&self, filename: &str) -> Result<WaitCommit> {
         self.pool.delete_db(filename)
+    }
+
+    /// Wait until every commit queued before this call has completed.
+    ///
+    /// SQLite's synchronous commit callback cannot await IndexedDB, so ordinary
+    /// VFS sync notifications are intentionally fire-and-forget. This barrier
+    /// is ordered on the same queue and reports every earlier failure, including
+    /// failures whose original notification had no receiver.
+    pub fn barrier(&self) -> Result<WaitCommit> {
+        self.pool.barrier()
     }
 
     /// Delete all database, make sure that all database is closed.

--- a/crates/sqlite-wasm-vfs/src/relaxed_idb.rs
+++ b/crates/sqlite-wasm-vfs/src/relaxed_idb.rs
@@ -366,7 +366,7 @@ struct RelaxedIdb {
     commit_errors: RefCell<Vec<CommitFailure>>,
     fatal_error: RefCell<Option<String>>,
     #[cfg(feature = "test-util")]
-    fail_next_commit: Cell<bool>,
+    fail_commits: Cell<u32>,
 }
 
 struct CommitFailure {
@@ -400,7 +400,7 @@ impl RelaxedIdb {
             commit_errors: RefCell::new(Vec::new()),
             fatal_error: RefCell::new(None),
             #[cfg(feature = "test-util")]
-            fail_next_commit: Cell::new(false),
+            fail_commits: Cell::new(0),
         })
     }
 
@@ -677,7 +677,9 @@ impl RelaxedIdb {
 
     #[cfg(feature = "test-util")]
     fn should_fail_next_commit(&self) -> bool {
-        self.fail_next_commit.replace(false)
+        let remaining = self.fail_commits.get();
+        self.fail_commits.set(remaining.saturating_sub(1));
+        remaining > 0
     }
 
     #[cfg(not(feature = "test-util"))]
@@ -723,6 +725,19 @@ impl RelaxedIdb {
             })
     }
 
+    fn retain_unresolved(&self, unresolved: &mut Vec<CommitFailure>, failure: CommitFailure) {
+        if let Some(existing) = unresolved
+            .iter_mut()
+            .find(|existing| same_op(&existing.op, &failure.op))
+        {
+            existing.count = existing.count.saturating_add(failure.count);
+        } else if unresolved.len() < 32 {
+            unresolved.push(failure);
+        } else {
+            *self.fatal_error.borrow_mut() = Some("too many unresolved IndexedDB failures".into());
+        }
+    }
+
     fn retry_operation<'a>(
         &'a self,
         op: &'a IdbCommitOp,
@@ -755,12 +770,15 @@ impl RelaxedIdb {
             }
             match self.retry_operation(&failure.op).await {
                 Ok(()) => reported = Some(failure.message),
-                Err(error) => unresolved.push(CommitFailure {
-                    op: failure.op,
-                    incarnation: failure.incarnation,
-                    message: format!("{}; retry failed: {error}", failure.message),
-                    count: failure.count,
-                }),
+                Err(_error) => self.retain_unresolved(
+                    &mut unresolved,
+                    CommitFailure {
+                        op: failure.op,
+                        incarnation: failure.incarnation,
+                        message: failure.message,
+                        count: failure.count.saturating_add(1),
+                    },
+                ),
             }
         }
         let mut files = self.name2file.borrow().keys().cloned().collect::<Vec<_>>();
@@ -774,12 +792,15 @@ impl RelaxedIdb {
                     *self.fatal_error.borrow_mut() = Some(error.to_string());
                     return Err(error);
                 }
-                unresolved.push(CommitFailure {
-                    op: IdbCommitOp::Sync(name),
-                    incarnation,
-                    message: error.to_string(),
-                    count: 1,
-                });
+                self.retain_unresolved(
+                    &mut unresolved,
+                    CommitFailure {
+                        op: IdbCommitOp::Sync(name),
+                        incarnation,
+                        message: error.to_string(),
+                        count: 1,
+                    },
+                );
             }
         }
         if !unresolved.is_empty() {
@@ -1154,7 +1175,12 @@ impl RelaxedIdbUtil {
 
     #[cfg(feature = "test-util")]
     pub fn fail_next_commit(&self) {
-        self.pool.fail_next_commit.set(true);
+        self.pool.fail_commits.set(1);
+    }
+
+    #[cfg(feature = "test-util")]
+    pub fn fail_commits(&self, count: u32) {
+        self.pool.fail_commits.set(count);
     }
 
     #[cfg(feature = "test-util")]

--- a/crates/sqlite-wasm-vfs/src/relaxed_idb.rs
+++ b/crates/sqlite-wasm-vfs/src/relaxed_idb.rs
@@ -54,9 +54,9 @@ use rsqlite_vfs::{
     register_vfs, registered_vfs, ImportDbError, MemChunksFile, OsCallback, RegisterVfsError,
     SQLiteIoMethods, SQLiteVfs, SQLiteVfsFile, VfsAppData, VfsError, VfsFile, VfsResult, VfsStore,
 };
-#[cfg(feature = "test-util")]
-use std::cell::Cell;
 use std::time::Duration;
+#[cfg(feature = "test-util")]
+use std::{cell::Cell, rc::Rc};
 use std::{cell::RefCell, marker::PhantomData};
 
 use indexed_db_futures::database::Database;
@@ -367,6 +367,8 @@ struct RelaxedIdb {
     fatal_error: RefCell<Option<String>>,
     #[cfg(feature = "test-util")]
     fail_commits: Cell<u32>,
+    #[cfg(feature = "test-util")]
+    pause_after_snapshot: RefCell<Option<(Rc<tokio::sync::Semaphore>, Rc<tokio::sync::Notify>)>>,
 }
 
 struct CommitFailure {
@@ -401,6 +403,8 @@ impl RelaxedIdb {
             fatal_error: RefCell::new(None),
             #[cfg(feature = "test-util")]
             fail_commits: Cell::new(0),
+            #[cfg(feature = "test-util")]
+            pause_after_snapshot: RefCell::new(None),
         })
     }
 
@@ -603,6 +607,12 @@ impl RelaxedIdb {
         if blocks_to_put.is_empty() && !has_truncation {
             // no need to put or delete
             return Ok(());
+        }
+
+        #[cfg(feature = "test-util")]
+        if let Some((gate, entered)) = self.pause_after_snapshot.borrow_mut().take() {
+            entered.notify_one();
+            gate.acquire().await.expect("snapshot test gate").forget();
         }
 
         let path = JsValue::from(file);
@@ -1181,6 +1191,15 @@ impl RelaxedIdbUtil {
     #[cfg(feature = "test-util")]
     pub fn fail_commits(&self, count: u32) {
         self.pool.fail_commits.set(count);
+    }
+
+    #[cfg(feature = "test-util")]
+    pub fn pause_after_snapshot(&self) -> (Rc<tokio::sync::Semaphore>, Rc<tokio::sync::Notify>) {
+        let gate = Rc::new(tokio::sync::Semaphore::new(0));
+        let entered = Rc::new(tokio::sync::Notify::new());
+        *self.pool.pause_after_snapshot.borrow_mut() =
+            Some((Rc::clone(&gate), Rc::clone(&entered)));
+        (gate, entered)
     }
 
     #[cfg(feature = "test-util")]

--- a/crates/sqlite-wasm-vfs/src/relaxed_idb.rs
+++ b/crates/sqlite-wasm-vfs/src/relaxed_idb.rs
@@ -55,7 +55,10 @@ use rsqlite_vfs::{
     SQLiteIoMethods, SQLiteVfs, SQLiteVfsFile, VfsAppData, VfsError, VfsFile, VfsResult, VfsStore,
 };
 use std::time::Duration;
-use std::{cell::RefCell, marker::PhantomData};
+use std::{
+    cell::{Cell, RefCell},
+    marker::PhantomData,
+};
 
 use indexed_db_futures::database::Database;
 use indexed_db_futures::prelude::*;
@@ -68,6 +71,7 @@ use std::task::{Context, Poll};
 use std::{
     collections::HashMap,
     ffi::{c_char, CStr},
+    sync::atomic::{AtomicU64, Ordering},
 };
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use wasm_bindgen::JsValue;
@@ -130,7 +134,7 @@ enum IdbCommitOp {
     Sync(String),
     Delete(String),
     Clear,
-    Barrier,
+    Barrier(String),
 }
 
 enum IdbFile {
@@ -148,13 +152,31 @@ impl IdbFile {
     }
 }
 
-#[derive(Default)]
 struct IdbPageFile {
+    incarnation: u64,
     file_size: usize,
     block_size: usize,
     blocks: HashMap<usize, Uint8Array>,
+    block_generation: HashMap<usize, u64>,
     tx_blocks: HashSet<usize>,
     sync_notified: bool,
+}
+
+static NEXT_FILE_INCARNATION: AtomicU64 = AtomicU64::new(1);
+static NEXT_BLOCK_GENERATION: AtomicU64 = AtomicU64::new(1);
+
+impl Default for IdbPageFile {
+    fn default() -> Self {
+        Self {
+            incarnation: NEXT_FILE_INCARNATION.fetch_add(1, Ordering::Relaxed),
+            file_size: 0,
+            block_size: 0,
+            blocks: HashMap::new(),
+            block_generation: HashMap::new(),
+            tx_blocks: HashSet::new(),
+            sync_notified: false,
+        }
+    }
 }
 
 impl VfsFile for IdbPageFile {
@@ -177,6 +199,8 @@ impl VfsFile for IdbPageFile {
         for fill in (self.file_size..offset).step_by(page_size) {
             self.blocks
                 .insert(fill, Uint8Array::new_with_length(page_size as u32));
+            self.block_generation
+                .insert(fill, NEXT_BLOCK_GENERATION.fetch_add(1, Ordering::Relaxed));
             self.tx_blocks.insert(fill);
         }
 
@@ -186,6 +210,10 @@ impl VfsFile for IdbPageFile {
             self.blocks.insert(offset, Uint8Array::new_from_slice(buf));
         }
 
+        self.block_generation.insert(
+            offset,
+            NEXT_BLOCK_GENERATION.fetch_add(1, Ordering::Relaxed),
+        );
         self.tx_blocks.insert(offset);
         self.block_size = page_size;
         self.file_size = self.file_size.max(offset + page_size);
@@ -286,12 +314,21 @@ async fn preload_db_impl(
                 };
                 db.file_size += db.block_size;
                 db.blocks.insert(offset, data);
+                db.block_generation.insert(
+                    offset,
+                    NEXT_BLOCK_GENERATION.fetch_add(1, Ordering::Relaxed),
+                );
             }
             hash_map::Entry::Vacant(vacant_entry) => {
                 vacant_entry.insert(IdbFile::Main(IdbPageFile {
+                    incarnation: NEXT_FILE_INCARNATION.fetch_add(1, Ordering::Relaxed),
                     file_size: data.length() as _,
                     block_size: data.length() as _,
                     blocks: HashMap::from([(offset, data)]),
+                    block_generation: HashMap::from([(
+                        offset,
+                        NEXT_BLOCK_GENERATION.fetch_add(1, Ordering::Relaxed),
+                    )]),
                     tx_blocks: HashSet::new(),
                     sync_notified: false,
                 }));
@@ -326,7 +363,14 @@ struct RelaxedIdb {
     idb: Database,
     name2file: RefCell<HashMap<String, IdbFile>>,
     tx: UnboundedSender<IdbCommit>,
-    commit_errors: RefCell<Vec<String>>,
+    commit_error: RefCell<Option<CommitFailure>>,
+    #[cfg(feature = "test-util")]
+    fail_next_commit: Cell<bool>,
+}
+
+struct CommitFailure {
+    message: String,
+    count: u32,
 }
 
 impl RelaxedIdb {
@@ -350,7 +394,9 @@ impl RelaxedIdb {
             idb: indexed_db,
             name2file: RefCell::new(name2file),
             tx,
-            commit_errors: RefCell::new(Vec::new()),
+            commit_error: RefCell::new(None),
+            #[cfg(feature = "test-util")]
+            fail_next_commit: Cell::new(false),
         })
     }
 
@@ -377,8 +423,8 @@ impl RelaxedIdb {
         Ok(WaitCommit(rx))
     }
 
-    fn barrier(&self) -> Result<WaitCommit> {
-        self.send_task_with_notify(IdbCommitOp::Barrier)
+    fn barrier(&self, filename: &str) -> Result<WaitCommit> {
+        self.send_task_with_notify(IdbCommitOp::Barrier(filename.into()))
     }
 
     async fn preload_db(&self, files: Vec<String>) -> Result<()> {
@@ -427,13 +473,24 @@ impl RelaxedIdb {
         }
 
         let tx_blocks = blocks.keys().copied().collect();
+        let block_generation = blocks
+            .keys()
+            .map(|offset| {
+                (
+                    *offset,
+                    NEXT_BLOCK_GENERATION.fetch_add(1, Ordering::Relaxed),
+                )
+            })
+            .collect();
 
         self.name2file.borrow_mut().insert(
             filename.into(),
             IdbFile::Main(IdbPageFile {
+                incarnation: NEXT_FILE_INCARNATION.fetch_add(1, Ordering::Relaxed),
                 file_size: blocks.len() * page_size,
                 block_size: page_size,
                 blocks,
+                block_generation,
                 tx_blocks,
                 sync_notified: false,
             }),
@@ -495,32 +552,48 @@ impl RelaxedIdb {
         Ok(())
     }
 
-    // already drop
-    #[allow(clippy::await_holding_refcell_ref)]
     async fn sync_db_impl(&self, file: &str) -> Result<()> {
         if let Some(IdbFile::Main(idb_blocks)) = self.name2file.borrow_mut().get_mut(file) {
             idb_blocks.sync_notified = false;
         }
 
-        let (file_size, tx_blocks, blocks_to_put, has_truncation) = {
+        let (incarnation, file_size, tx_blocks, blocks_to_put, has_truncation) = {
             let name2file = self.name2file.borrow();
             let Some(IdbFile::Main(idb_blocks)) = name2file.get(file) else {
                 return Ok(());
             };
 
+            let incarnation = idb_blocks.incarnation;
             let file_size = idb_blocks.file_size;
             let tx_blocks: Vec<_> = idb_blocks.tx_blocks.iter().copied().collect();
             let blocks_to_put: Vec<_> = tx_blocks
                 .iter()
                 .filter_map(|offset| {
-                    idb_blocks
-                        .blocks
-                        .get(offset)
-                        .map(|buffer| (*offset, buffer.clone()))
+                    let buffer = idb_blocks.blocks.get(offset)?;
+                    if *offset >= file_size {
+                        return None;
+                    }
+                    let mut bytes = vec![0; buffer.length() as usize];
+                    buffer.copy_to(&mut bytes);
+                    Some((
+                        *offset,
+                        idb_blocks
+                            .block_generation
+                            .get(offset)
+                            .copied()
+                            .unwrap_or(0),
+                        Uint8Array::new_from_slice(&bytes),
+                    ))
                 })
                 .collect();
             let has_truncation = idb_blocks.blocks.keys().any(|offset| *offset >= file_size);
-            (file_size, tx_blocks, blocks_to_put, has_truncation)
+            (
+                incarnation,
+                file_size,
+                tx_blocks,
+                blocks_to_put,
+                has_truncation,
+            )
         };
 
         if blocks_to_put.is_empty() && !has_truncation {
@@ -538,7 +611,7 @@ impl RelaxedIdb {
 
         let store = transaction.object_store("blocks")?;
 
-        for (offset, buffer) in &blocks_to_put {
+        for (offset, _, buffer) in &blocks_to_put {
             store.put(&set_block(&path, *offset, buffer)).build()?;
         }
         store.delete(key_range(file, file_size)).build()?;
@@ -546,11 +619,23 @@ impl RelaxedIdb {
 
         let mut name2file = self.name2file.borrow_mut();
         if let Some(IdbFile::Main(idb_blocks)) = name2file.get_mut(file) {
-            idb_blocks
-                .blocks
-                .retain(|offset, _| *offset < idb_blocks.file_size);
-            for offset in tx_blocks {
-                idb_blocks.tx_blocks.remove(&offset);
+            if idb_blocks.incarnation == incarnation {
+                for (offset, generation, _) in &blocks_to_put {
+                    if idb_blocks.block_generation.get(offset) == Some(generation) {
+                        idb_blocks.tx_blocks.remove(offset);
+                    }
+                }
+                if idb_blocks.file_size == file_size {
+                    idb_blocks.blocks.retain(|offset, _| *offset < file_size);
+                    idb_blocks
+                        .block_generation
+                        .retain(|offset, _| *offset < file_size);
+                    for offset in tx_blocks {
+                        if offset >= file_size {
+                            idb_blocks.tx_blocks.remove(&offset);
+                        }
+                    }
+                }
             }
             idb_blocks.sync_notified = false;
         }
@@ -561,32 +646,71 @@ impl RelaxedIdb {
     async fn commit_loop(&self, mut rx: UnboundedReceiver<IdbCommit>) {
         while let Some(commit) = rx.recv().await {
             let IdbCommit { op, notify } = commit;
-            let is_barrier = matches!(&op, IdbCommitOp::Barrier);
-            let ret = match op {
-                IdbCommitOp::Sync(file) => self.sync_db_impl(&file).await,
-                IdbCommitOp::Delete(file) => self.delete_db_impl(&file).await,
-                IdbCommitOp::Clear => clear_impl(&self.idb).await,
-                IdbCommitOp::Barrier => {
-                    let errors = std::mem::take(&mut *self.commit_errors.borrow_mut());
-                    if errors.is_empty() {
-                        Ok(())
-                    } else {
-                        Err(RelaxedIdbError::Generic(format!(
-                            "one or more IndexedDB commits failed: {}",
-                            errors.join("; ")
-                        )))
-                    }
+            let is_barrier = matches!(&op, IdbCommitOp::Barrier(_));
+            let ret = if !is_barrier && self.should_fail_next_commit() {
+                Err(RelaxedIdbError::Generic("injected commit failure".into()))
+            } else {
+                match op {
+                    IdbCommitOp::Sync(file) => self.sync_db_impl(&file).await,
+                    IdbCommitOp::Delete(file) => self.delete_db_impl(&file).await,
+                    IdbCommitOp::Clear => clear_impl(&self.idb).await,
+                    IdbCommitOp::Barrier(file) => self.barrier_impl(&file).await,
                 }
             };
             if !is_barrier {
                 if let Err(error) = &ret {
-                    self.commit_errors.borrow_mut().push(error.to_string());
+                    self.record_commit_error(error);
                 }
             }
             if let Some(notify) = notify {
                 // An unsuccessful send would be one where the corresponding receiver
                 // has already been deallocated.
                 let _ = notify.send(ret);
+            }
+        }
+    }
+
+    #[cfg(feature = "test-util")]
+    fn should_fail_next_commit(&self) -> bool {
+        self.fail_next_commit.replace(false)
+    }
+
+    fn record_commit_error(&self, error: &RelaxedIdbError) {
+        let mut pending = self.commit_error.borrow_mut();
+        match pending.as_mut() {
+            Some(failure) => failure.count = failure.count.saturating_add(1),
+            None => {
+                *pending = Some(CommitFailure {
+                    message: error.to_string(),
+                    count: 1,
+                });
+            }
+        }
+    }
+
+    async fn barrier_impl(&self, file: &str) -> Result<()> {
+        let retry = self.sync_db_impl(file).await;
+        let pending = self.commit_error.borrow_mut().take();
+        match (pending, retry) {
+            (None, Ok(())) => Ok(()),
+            (None, Err(error)) => {
+                self.record_commit_error(&error);
+                Err(error)
+            }
+            (Some(failure), Ok(())) => Err(RelaxedIdbError::Generic(format!(
+                "an earlier IndexedDB commit failed ({} occurrence{}): {}",
+                failure.count,
+                if failure.count == 1 { "" } else { "s" },
+                failure.message
+            ))),
+            (Some(failure), Err(error)) => {
+                self.record_commit_error(&error);
+                Err(RelaxedIdbError::Generic(format!(
+                    "an earlier IndexedDB commit failed ({} occurrence{}): {}; retry failed: {error}",
+                    failure.count,
+                    if failure.count == 1 { "" } else { "s" },
+                    failure.message
+                )))
             }
         }
     }
@@ -927,8 +1051,13 @@ impl RelaxedIdbUtil {
     /// VFS sync notifications are intentionally fire-and-forget. This barrier
     /// is ordered on the same queue and reports every earlier failure, including
     /// failures whose original notification had no receiver.
-    pub fn barrier(&self) -> Result<WaitCommit> {
-        self.pool.barrier()
+    pub fn barrier(&self, filename: &str) -> Result<WaitCommit> {
+        self.pool.barrier(filename)
+    }
+
+    #[cfg(feature = "test-util")]
+    pub fn fail_next_commit(&self) {
+        self.pool.fail_next_commit.set(true);
     }
 
     /// Delete all database, make sure that all database is closed.

--- a/crates/sqlite-wasm-vfs/src/relaxed_idb.rs
+++ b/crates/sqlite-wasm-vfs/src/relaxed_idb.rs
@@ -54,11 +54,10 @@ use rsqlite_vfs::{
     register_vfs, registered_vfs, ImportDbError, MemChunksFile, OsCallback, RegisterVfsError,
     SQLiteIoMethods, SQLiteVfs, SQLiteVfsFile, VfsAppData, VfsError, VfsFile, VfsResult, VfsStore,
 };
+#[cfg(feature = "test-util")]
+use std::cell::Cell;
 use std::time::Duration;
-use std::{
-    cell::{Cell, RefCell},
-    marker::PhantomData,
-};
+use std::{cell::RefCell, marker::PhantomData};
 
 use indexed_db_futures::database::Database;
 use indexed_db_futures::prelude::*;
@@ -130,6 +129,7 @@ struct IdbCommit {
     notify: Option<tokio::sync::oneshot::Sender<Result<()>>>,
 }
 
+#[derive(Clone)]
 enum IdbCommitOp {
     Sync(String),
     Delete(String),
@@ -363,12 +363,13 @@ struct RelaxedIdb {
     idb: Database,
     name2file: RefCell<HashMap<String, IdbFile>>,
     tx: UnboundedSender<IdbCommit>,
-    commit_error: RefCell<Option<CommitFailure>>,
+    commit_errors: RefCell<Vec<CommitFailure>>,
     #[cfg(feature = "test-util")]
     fail_next_commit: Cell<bool>,
 }
 
 struct CommitFailure {
+    op: IdbCommitOp,
     message: String,
     count: u32,
 }
@@ -394,7 +395,7 @@ impl RelaxedIdb {
             idb: indexed_db,
             name2file: RefCell::new(name2file),
             tx,
-            commit_error: RefCell::new(None),
+            commit_errors: RefCell::new(Vec::new()),
             #[cfg(feature = "test-util")]
             fail_next_commit: Cell::new(false),
         })
@@ -647,6 +648,7 @@ impl RelaxedIdb {
         while let Some(commit) = rx.recv().await {
             let IdbCommit { op, notify } = commit;
             let is_barrier = matches!(&op, IdbCommitOp::Barrier(_));
+            let failed_op = op.clone();
             let ret = if !is_barrier && self.should_fail_next_commit() {
                 Err(RelaxedIdbError::Generic("injected commit failure".into()))
             } else {
@@ -659,7 +661,7 @@ impl RelaxedIdb {
             };
             if !is_barrier {
                 if let Err(error) = &ret {
-                    self.record_commit_error(error);
+                    self.record_commit_error(failed_op, error);
                 }
             }
             if let Some(notify) = notify {
@@ -675,44 +677,88 @@ impl RelaxedIdb {
         self.fail_next_commit.replace(false)
     }
 
-    fn record_commit_error(&self, error: &RelaxedIdbError) {
-        let mut pending = self.commit_error.borrow_mut();
-        match pending.as_mut() {
-            Some(failure) => failure.count = failure.count.saturating_add(1),
-            None => {
-                *pending = Some(CommitFailure {
+    #[cfg(not(feature = "test-util"))]
+    fn should_fail_next_commit(&self) -> bool {
+        false
+    }
+
+    fn record_commit_error(&self, op: IdbCommitOp, error: &RelaxedIdbError) {
+        let mut pending = self.commit_errors.borrow_mut();
+        if let Some(failure) = pending.iter_mut().find(|failure| same_op(&failure.op, &op)) {
+            failure.count = failure.count.saturating_add(1);
+        } else if pending.len() < 32 {
+            pending.push(CommitFailure {
+                op,
+                message: error.to_string(),
+                count: 1,
+            });
+        } else if let Some(failure) = pending.last_mut() {
+            failure.count = failure.count.saturating_add(1);
+        }
+    }
+
+    fn retry_operation<'a>(
+        &'a self,
+        op: &'a IdbCommitOp,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + 'a>> {
+        Box::pin(async move {
+            match op {
+                IdbCommitOp::Sync(file) => self.sync_db_impl(file).await,
+                IdbCommitOp::Delete(file) => self.delete_db_impl(file).await,
+                IdbCommitOp::Clear => clear_impl(&self.idb).await,
+                IdbCommitOp::Barrier(_) => Ok(()),
+            }
+        })
+    }
+
+    async fn barrier_impl(&self, file: &str) -> Result<()> {
+        let pending = std::mem::take(&mut *self.commit_errors.borrow_mut());
+        let mut unresolved = Vec::new();
+        let mut reported = None;
+        for failure in pending {
+            match self.retry_operation(&failure.op).await {
+                Ok(()) => reported = Some(failure.message),
+                Err(error) => unresolved.push(CommitFailure {
+                    op: failure.op,
+                    message: format!("{}; retry failed: {error}", failure.message),
+                    count: failure.count,
+                }),
+            }
+        }
+        let mut files = self.name2file.borrow().keys().cloned().collect::<Vec<_>>();
+        if !files.iter().any(|name| name == file) {
+            files.push(file.to_string());
+        }
+        for name in files {
+            if let Err(error) = self.sync_db_impl(&name).await {
+                unresolved.push(CommitFailure {
+                    op: IdbCommitOp::Sync(name),
                     message: error.to_string(),
                     count: 1,
                 });
             }
         }
-    }
-
-    async fn barrier_impl(&self, file: &str) -> Result<()> {
-        let retry = self.sync_db_impl(file).await;
-        let pending = self.commit_error.borrow_mut().take();
-        match (pending, retry) {
-            (None, Ok(())) => Ok(()),
-            (None, Err(error)) => {
-                self.record_commit_error(&error);
-                Err(error)
-            }
-            (Some(failure), Ok(())) => Err(RelaxedIdbError::Generic(format!(
-                "an earlier IndexedDB commit failed ({} occurrence{}): {}",
-                failure.count,
-                if failure.count == 1 { "" } else { "s" },
-                failure.message
-            ))),
-            (Some(failure), Err(error)) => {
-                self.record_commit_error(&error);
-                Err(RelaxedIdbError::Generic(format!(
-                    "an earlier IndexedDB commit failed ({} occurrence{}): {}; retry failed: {error}",
-                    failure.count,
-                    if failure.count == 1 { "" } else { "s" },
-                    failure.message
-                )))
-            }
+        if !unresolved.is_empty() {
+            let message = unresolved
+                .first()
+                .map(|failure| failure.message.clone())
+                .unwrap_or_else(|| "IndexedDB commit failed".into());
+            *self.commit_errors.borrow_mut() = unresolved;
+            return Err(RelaxedIdbError::Generic(message));
         }
+        if let Some(message) = reported {
+            return Err(RelaxedIdbError::Generic(message));
+        }
+        Ok(())
+    }
+}
+
+fn same_op(left: &IdbCommitOp, right: &IdbCommitOp) -> bool {
+    match (left, right) {
+        (IdbCommitOp::Sync(a), IdbCommitOp::Sync(b))
+        | (IdbCommitOp::Delete(a), IdbCommitOp::Delete(b)) => a == b,
+        (IdbCommitOp::Clear, IdbCommitOp::Clear) => true,
+        _ => false,
     }
 }
 
@@ -1058,6 +1104,11 @@ impl RelaxedIdbUtil {
     #[cfg(feature = "test-util")]
     pub fn fail_next_commit(&self) {
         self.pool.fail_next_commit.set(true);
+    }
+
+    #[cfg(feature = "test-util")]
+    pub fn forget_memory_file(&self, filename: &str) {
+        self.pool.name2file.borrow_mut().remove(filename);
     }
 
     /// Delete all database, make sure that all database is closed.

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -8,6 +8,8 @@ publish = false
 sqlite-wasm-vfs = { version = "0.2.0", features = ["test-util"] }
 sqlite-wasm-rs = "0.5.0"
 wasm-bindgen-test = "0.3.54"
+wasm-bindgen-futures = "0.4.54"
+wasm-bindgen = "0.2.104"
 
 [features]
 sqlite3mc = ["sqlite-wasm-rs/sqlite3mc"]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-sqlite-wasm-vfs = "0.2.0"
+sqlite-wasm-vfs = { version = "0.2.0", features = ["test-util"] }
 sqlite-wasm-rs = "0.5.0"
 wasm-bindgen-test = "0.3.54"
 

--- a/tests/tests/full/vfs/relaxed_idb.rs
+++ b/tests/tests/full/vfs/relaxed_idb.rs
@@ -185,6 +185,60 @@ async fn test_idb_vfs_barrier_reports_failure_before_retrying_dirty_blocks() {
         .unwrap()
         .await
         .is_ok());
+    util.forget_memory_file("test_idb_vfs_barrier_failure.db");
+    util.preload_db(vec!["test_idb_vfs_barrier_failure.db".into()])
+        .await
+        .unwrap();
+    assert!(!util
+        .export_db("test_idb_vfs_barrier_failure.db")
+        .unwrap()
+        .is_empty());
+}
+
+#[wasm_bindgen_test]
+async fn test_idb_vfs_barrier_retries_failed_delete() {
+    let util = install_idb_vfs(
+        &RelaxedIdbCfgBuilder::new()
+            .vfs_name("relaxed-idb-barrier-delete")
+            .clear_on_init(true)
+            .preload(Preload::None)
+            .build(),
+        true,
+    )
+    .await
+    .unwrap();
+    util.preload_db(vec!["test_idb_vfs_barrier_delete.db".into()])
+        .await
+        .unwrap();
+    let mut db = std::ptr::null_mut();
+    let ret = unsafe {
+        sqlite3_open_v2(
+            c"test_idb_vfs_barrier_delete.db".as_ptr(),
+            &mut db as *mut _,
+            SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE,
+            std::ptr::null_mut(),
+        )
+    };
+    assert_eq!(SQLITE_OK, ret);
+    prepare_simple_db(db);
+    unsafe { sqlite3_close(db) };
+    util.barrier("test_idb_vfs_barrier_delete.db")
+        .unwrap()
+        .await
+        .unwrap();
+
+    util.fail_next_commit();
+    util.delete_db("test_idb_vfs_barrier_delete.db").unwrap();
+    assert!(util
+        .barrier("test_idb_vfs_barrier_delete.db")
+        .unwrap()
+        .await
+        .is_err());
+    assert!(util
+        .barrier("test_idb_vfs_barrier_delete.db")
+        .unwrap()
+        .await
+        .is_ok());
 }
 
 #[wasm_bindgen_test]

--- a/tests/tests/full/vfs/relaxed_idb.rs
+++ b/tests/tests/full/vfs/relaxed_idb.rs
@@ -111,6 +111,8 @@ async fn test_idb_vfs_utils() {
         sqlite3_close(db);
     };
 
+    util.barrier().unwrap().await.unwrap();
+
     // export and import to new.db
     let db = util.export_db("test_idb_vfs_utils.db").unwrap();
     util.import_db("new.db", &db).unwrap().await.unwrap();

--- a/tests/tests/full/vfs/relaxed_idb.rs
+++ b/tests/tests/full/vfs/relaxed_idb.rs
@@ -196,7 +196,7 @@ async fn test_idb_vfs_barrier_reports_failure_before_retrying_dirty_blocks() {
 }
 
 #[wasm_bindgen_test]
-async fn test_idb_vfs_barrier_retries_failed_delete() {
+async fn test_idb_vfs_barrier_poisoned_after_failed_delete() {
     let util = install_idb_vfs(
         &RelaxedIdbCfgBuilder::new()
             .vfs_name("relaxed-idb-barrier-delete")

--- a/tests/tests/full/vfs/relaxed_idb.rs
+++ b/tests/tests/full/vfs/relaxed_idb.rs
@@ -111,7 +111,10 @@ async fn test_idb_vfs_utils() {
         sqlite3_close(db);
     };
 
-    util.barrier().unwrap().await.unwrap();
+    util.barrier("test_idb_vfs_utils.db")
+        .unwrap()
+        .await
+        .unwrap();
 
     // export and import to new.db
     let db = util.export_db("test_idb_vfs_utils.db").unwrap();
@@ -140,6 +143,48 @@ async fn test_idb_vfs_utils() {
         .await
         .unwrap();
     util.delete_db("new.db").unwrap().await.unwrap();
+}
+
+#[wasm_bindgen_test]
+async fn test_idb_vfs_barrier_reports_failure_before_retrying_dirty_blocks() {
+    let util = install_idb_vfs(
+        &RelaxedIdbCfgBuilder::new()
+            .vfs_name("relaxed-idb-barrier-failure")
+            .clear_on_init(true)
+            .preload(Preload::None)
+            .build(),
+        true,
+    )
+    .await
+    .unwrap();
+    util.preload_db(vec!["test_idb_vfs_barrier_failure.db".into()])
+        .await
+        .unwrap();
+
+    let mut db = std::ptr::null_mut();
+    let ret = unsafe {
+        sqlite3_open_v2(
+            c"test_idb_vfs_barrier_failure.db".as_ptr(),
+            &mut db as *mut _,
+            SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE,
+            std::ptr::null_mut(),
+        )
+    };
+    assert_eq!(SQLITE_OK, ret);
+    prepare_simple_db(db);
+    unsafe { sqlite3_close(db) };
+
+    util.fail_next_commit();
+    assert!(util
+        .barrier("test_idb_vfs_barrier_failure.db")
+        .unwrap()
+        .await
+        .is_err());
+    assert!(util
+        .barrier("test_idb_vfs_barrier_failure.db")
+        .unwrap()
+        .await
+        .is_ok());
 }
 
 #[wasm_bindgen_test]

--- a/tests/tests/full/vfs/relaxed_idb.rs
+++ b/tests/tests/full/vfs/relaxed_idb.rs
@@ -234,11 +234,23 @@ async fn test_idb_vfs_barrier_retries_failed_delete() {
         .unwrap()
         .await
         .is_err());
+    let mut db = std::ptr::null_mut();
+    let ret = unsafe {
+        sqlite3_open_v2(
+            c"test_idb_vfs_barrier_delete.db".as_ptr(),
+            &mut db as *mut _,
+            SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE,
+            std::ptr::null_mut(),
+        )
+    };
+    assert_eq!(SQLITE_OK, ret);
+    prepare_simple_db(db);
+    unsafe { sqlite3_close(db) };
     assert!(util
         .barrier("test_idb_vfs_barrier_delete.db")
         .unwrap()
         .await
-        .is_ok());
+        .is_err());
 }
 
 #[wasm_bindgen_test]

--- a/tests/tests/full/vfs/relaxed_idb.rs
+++ b/tests/tests/full/vfs/relaxed_idb.rs
@@ -254,6 +254,114 @@ async fn test_idb_vfs_barrier_poisoned_after_failed_delete() {
 }
 
 #[wasm_bindgen_test]
+async fn test_idb_vfs_preserves_a_newer_write_during_commit() {
+    let options = RelaxedIdbCfgBuilder::new()
+        .vfs_name("relaxed-idb-overwrite")
+        .clear_on_init(true)
+        .preload(Preload::None)
+        .build();
+    let util = install_idb_vfs(&options, true).await.unwrap();
+    let filename = "test_idb_vfs_overwrite.db";
+    util.preload_db(vec![filename.into()]).await.unwrap();
+    let mut db = std::ptr::null_mut();
+    let ret = unsafe {
+        sqlite3_open_v2(
+            c"test_idb_vfs_overwrite.db".as_ptr(),
+            &mut db as *mut _,
+            SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE,
+            std::ptr::null_mut(),
+        )
+    };
+    assert_eq!(SQLITE_OK, ret);
+    prepare_simple_db(db);
+    unsafe { sqlite3_close(db) };
+    let (gate, entered) = util.pause_after_snapshot();
+    let waiting = install_idb_vfs(&options, false).await.unwrap();
+    wasm_bindgen_futures::spawn_local(async move {
+        let _ = waiting.barrier(filename).unwrap().await;
+    });
+    entered.notified().await;
+
+    let mut db = std::ptr::null_mut();
+    let ret = unsafe {
+        sqlite3_open_v2(
+            c"test_idb_vfs_overwrite.db".as_ptr(),
+            &mut db as *mut _,
+            SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE,
+            std::ptr::null_mut(),
+        )
+    };
+    assert_eq!(SQLITE_OK, ret);
+    let ret = unsafe {
+        sqlite3_exec(
+            db,
+            c"CREATE TABLE newer_marker (value TEXT); INSERT INTO newer_marker VALUES ('newer');"
+                .as_ptr(),
+            None,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+    };
+    assert_eq!(SQLITE_OK, ret);
+    unsafe { sqlite3_close(db) };
+    gate.add_permits(1);
+    util.barrier(filename).unwrap().await.unwrap();
+    util.forget_memory_file(filename);
+    util.preload_db(vec![filename.into()]).await.unwrap();
+    let mut reopened = std::ptr::null_mut();
+    let ret = unsafe {
+        sqlite3_open_v2(
+            c"test_idb_vfs_overwrite.db".as_ptr(),
+            &mut reopened as *mut _,
+            SQLITE_OPEN_READWRITE,
+            std::ptr::null_mut(),
+        )
+    };
+    assert_eq!(SQLITE_OK, ret);
+    let ret = unsafe {
+        sqlite3_exec(
+            reopened,
+            c"SELECT value FROM newer_marker".as_ptr(),
+            None,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+    };
+    assert_eq!(SQLITE_OK, ret);
+    unsafe { sqlite3_close(reopened) };
+}
+
+#[wasm_bindgen_test]
+async fn test_idb_vfs_overflow_failures_poison_the_barrier() {
+    let options = RelaxedIdbCfgBuilder::new()
+        .vfs_name("relaxed-idb-overflow")
+        .clear_on_init(true)
+        .preload(Preload::None)
+        .build();
+    let util = install_idb_vfs(&options, true).await.unwrap();
+    let mut db = std::ptr::null_mut();
+    let ret = unsafe {
+        sqlite3_open_v2(
+            c"test_idb_vfs_overflow_source.db".as_ptr(),
+            &mut db as *mut _,
+            SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE,
+            std::ptr::null_mut(),
+        )
+    };
+    assert_eq!(SQLITE_OK, ret);
+    prepare_simple_db(db);
+    unsafe { sqlite3_close(db) };
+    let bytes = util.export_db("test_idb_vfs_overflow_source.db").unwrap();
+    util.fail_commits(33);
+    for index in 0..33 {
+        let name = format!("overflow-{index}.db");
+        let _ = util.import_db(&name, &bytes).unwrap();
+    }
+    assert!(util.barrier("overflow-0.db").unwrap().await.is_err());
+    assert!(util.barrier("overflow-0.db").unwrap().await.is_err());
+}
+
+#[wasm_bindgen_test]
 async fn test_idb_vfs_set_page_size() {
     let util = install_idb_vfs(
         &RelaxedIdbCfgBuilder::new()


### PR DESCRIPTION
Relaxed IndexedDB currently queues SQLite sync notifications without an observable completion. This patch adds an ordered barrier for callers that must confirm backing IndexedDB durability before publishing state.

The implementation retains dirty blocks across failed transactions, snapshots bytes with file and block generations, bounds failure tracking, retries only safe sync failures, and permanently poisons the barrier after destructive delete/clear failures. The browser test utility injects deterministic failures to cover error propagation and recovery ordering.

Validation:

- `cargo fmt --all -- --check`
- `cargo check -p sqlite-wasm-vfs --target wasm32-unknown-unknown`
- `cargo check --manifest-path tests/Cargo.toml --target wasm32-unknown-unknown --tests`
- Headless Chrome browser suite: 15/15 passed with wasm-bindgen 0.2.128 and ChromeDriver 152
